### PR TITLE
fix: mount configs directory instead of cluster.hocon to avoid ebusy errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+emqx/*.config
+emqx/*.args
+emqx/*.bak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - 1883:1883
       - 18083:18083
     volumes:
-      - $PWD/emqx/cluster.hocon:/opt/emqx/data/configs/cluster.hocon
+      - $PWD/emqx:/opt/emqx/data/configs
       - $PWD/emqx/api_secret:/opt/emqx/data/api_secret
     environment:
       EMQX_DASHBOARD__BOOTSTRAP_USERS_FILE: '"/opt/emqx/data/api_secret"'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - $PWD/emqx:/opt/emqx/data/configs
       - $PWD/emqx/api_secret:/opt/emqx/data/api_secret
     environment:
-      EMQX_DASHBOARD__BOOTSTRAP_USERS_FILE: '"/opt/emqx/data/api_secret"'
+      EMQX_API_KEY__BOOTSTRAP_FILE: '"/opt/emqx/data/api_secret"'
     depends_on:
       mongo: 
         condition: service_started   


### PR DESCRIPTION
EMQX 5.1 backups/rotates cluster.hocon file, mounting it in docker-compose file will not allow to do it:

```
docker exec -it `docker container ls -f "ancestor=emqx/emqx-enterprise:5.1.0" -q` bashxo
emqx@e1f28a9ace23:/opt/emqx/data/configs$ df -a | grep emqx
/dev/sda2      244506940 84544200 147469684  37% /opt/emqx/data
/dev/sda2      244506940 84544200 147469684  37% /opt/emqx/log
/dev/sda2      244506940 84544200 147469684  37% /opt/emqx/data/api_secret
/dev/sda2      244506940 84544200 147469684  37% /opt/emqx/data/configs/cluster.hocon
emqx@e1f28a9ace23:/opt/emqx/data/configs$ mv cluster.hocon cluster.hocon.backup.test
mv: cannot move 'cluster.hocon' to 'cluster.hocon.backup.test': Device or resource busy
```

Some background about the error:
>        EBUSY  The rename fails because oldpath or newpath is a directory
>              that is in use by some process (perhaps as current working
>              directory, or as root directory, or because it was open
>              for reading) or is in use by the system (for example as a
>              mount point), while the system considers this an error.
>              (Note that there is no requirement to return EBUSY in such
>              cases—there is nothing wrong with doing the rename anyway—
>              but it is allowed to return EBUSY if the system cannot
>              otherwise handle such situations.)
Source: https://www.man7.org/linux/man-pages/man2/rename.2.html
